### PR TITLE
Summation for custom score only restraints, and fixing path issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,21 @@ These scripts are used to analyze a series of trajectories, look at their scores
 
 1. To initialize the analysis class:
 
-```
+```python
 AT = AnalysisTrajectories(out_dirs,
-			  dir_name = 'run_',
+						  dir_name = 'run_',
                           analysis_dir = analysis_dir,
-                          nproc=nproc)
-
+                          detect_equilibration=True,
+                          burn_in=1000,
+                          nskip=200,
+                          nproc=1,
+                          plot_fmt="pdf")
 ```
-Here *dir_name* is the prefix of the run folders, *analysis_dir* is the directory where all analysis output will be written, and *nproc* is the number of processor that will be used. 
+The minimum set of arguments to specify are ```dir_name```: the prefix of the run folders, ```analysis_dir```: the directory where all analysis output will be written, and ```nproc```: the number of processors that are used to do parallel I/O. Additional options are: ```detect_equilibration``` which when set to ```False``` turns off rigorous statistical determination of the burn-in  or equilibration phase and instead just discards a constant ```burn_in``` frames from each independent run, to calculate statistics. ```nskip``` is used to *thin* out the samples collected for analysis, i.e. every ```nskip```^th  frame is selected. Finally, ```plot_fmt``` specifies the file extension of all matplotlib figures generated. You should only set ```detect_equilibration=False``` if you are testing your analysis script and need it to run fast without waiting for calculating the exact length of the monte carlo burn-in phase. 
 
 2. Add the restraints that you want to be analyzed:
 
-```
+```python
 XLs_cutoffs = {'DSSO':30.0}
 AT.set_analyze_XLs_restraint(XLs_cutoffs = XLs_cutoffs)
 AT.set_analyze_Connectivity_restraint()
@@ -32,7 +35,7 @@ AT.set_analyze_Excluded_volume_restraint()
 
 If you set up more than one XLs restraint, you should include the *Multiple_XLs_restraints = True* flag in the analysis and include a cutoff for all of them in the *XLs_cutoffs* dictionary. For example, if you divided the DSSO XLs into a intra-subunit and inter-subunit datasets, there should be two elements in the *XLs_cutoffs* dictionary (even if they have the same cutoff):
 
-```
+```python
 XLs_cutoffs = {'DSSO_Inter':30.0, 'DSSO_Intra':30.0}
 AT.set_analyze_XLs_restraint(XLs_cutoffs = XLs_cutoffs,
                              Multiple_XLs_restraints = True)
@@ -41,19 +44,20 @@ Using the labels you used to setup the restraint and keys.
 
 Similarly, if there is ambiguity in the XLs assignments (i.e. you have multiple copies of the same protein), you should use the *ambiguous_XLs_restraint = True* option:
 
-```
+```python
 AT.set_analyze_XLs_restraint(XLs_cutoffs = XLs_cutoffs,
                              ambiguous_XLs_restraint = True)
-
 ```
 
-If you want to analyze a restraint that is not standard to IMP, you can do so by including the handle associated to that restraint in the stat file:
+If you want to analyze a restraint that is not standard to IMP, you can do so by including the handle associated to that restraint in the stat file. E.g. if your restraint is called ```COMDistanceRestraint_data_Score``` in the stat files produced after sampling (i.e. the restraint *handle*) and you'd like the restraint score to be referred to by a short name, say ```COM``` throughout the various analysis output data-frames:
 
-```
-AT.set_analyze_score_only_restraint('COMDistanceRestraint_data_Score')
+```python
+AT.set_analyze_score_only_restraint(handle='COMDistanceRestraint_data_Score',
+                                    short_name='COM',
+                                    do_sum=True)
 ```
 
-This will only analyze the scores (not any nuisances associated with it, or some other statistics).
+The ```do_sum=True``` option will add up all restraint scores that start with the restraint handle as specified (e.g. ```COMDistanceRestraint_data_Score_1```, ```COMDistanceRestraint_data_Score_2```, etc). In general it may be desirable to add scores of the same type prior to score based clustering, since that decreases the dimensionality of the score space and helps the clustering process converge better. E.g., restraints like connectivity and excluded volume have their scores added up by default. Note that this method will only analyze the scores for the restraint, not nuisances or other associated statistics. 
 
 
 3. Read the stat files to obtain the scores, nuisances parameters, and information about the rmf3 files:
@@ -62,7 +66,7 @@ This will only analyze the scores (not any nuisances associated with it, or some
 AT.read_stat_files()
 ```
 
-In this step we also automatically determine the equilibration time for each restraint and nuisance particles. Only models after equilibration are considered for further analysis.
+In this step we also automatically determine the equilibration time for each restraint and nuisance particles. Only models after equilibration are considered for further analysis (unless, as mentioned before the ```detect_equilibration``` option is set to False. )
 
 Reference for equilibration detection:
 
@@ -87,11 +91,11 @@ If you added a non-standard restraint, you can use it in clustering with the nam
 AT.summarize_XLs_info()
 
 ```
-This will create a series of files and plots summarizing the XLs distances and satisfaction in all the clusters obtained in step 6. Files $plot_run_models_cluster*.pdf$ show the number of models from each run that are in each cluster. Files $plot_scores_convegence_cluster*.pdf$ show the scores distribution for each cluster.
+This will create a series of files and plots summarizing the XLs distances and satisfaction in all the clusters obtained in step 6. Files ```plot_run_models_cluster*.<plot_fmt>``` show the number of models from each run that are in each cluster. Files ```plot_scores_convegence_cluster*.<plot_fmt>``` show the scores distribution for each cluster.
 
-Files all_info_*.csv contain the information about all models after equilibration. These files can be used to re-run the clustering step:
+Files ```all_info_*.csv``` contain the information about all models after equilibration. These files can be used to re-run the clustering step:
 
-```
+```python
 AT.read_models_info()
 AT.hdbscan_clustering(['EV_sum', 'XLs_sum'])
 ```

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ AT = AnalysisTrajectories(out_dirs,
                           dir_name = 'run_',
                           analysis_dir = analysis_dir,
                           detect_equilibration=True,
-                          burn_in=1000,
-                          nskip=200,
+                          burn_in_fraction=0.02,
+                          nskip=20,
                           nproc=1,
                           plot_fmt='pdf')
 ```
-The minimum set of arguments to specify are ```dir_name```: the prefix of the run folders, ```analysis_dir```: the directory where all analysis output will be written, and ```nproc```: the number of processors that are used to do parallel I/O. Additional options are: ```detect_equilibration``` which when set to ```False``` turns off rigorous statistical determination of the burn-in  or equilibration phase and instead just discards a constant ```burn_in``` frames from each independent run, to calculate statistics. ```nskip``` is used to *thin* out the samples collected for analysis, i.e. every ```nskip```^th  frame is selected. Finally, ```plot_fmt``` specifies the file extension of all matplotlib figures generated. You should only set ```detect_equilibration=False``` if you are testing your analysis script and need it to run fast without waiting for calculating the exact length of the monte carlo burn-in phase. 
+The minimum set of arguments to specify are ```dir_name```: the prefix of the run folders, ```analysis_dir```: the directory where all analysis output will be written, and ```nproc```: the number of processors that are used to do parallel I/O. Additional options are: ```detect_equilibration``` which when set to ```False``` turns off rigorous statistical determination of the burn-in  or equilibration phase and instead just discards a ```burn_in_fraction``` (default 2% of the trajectory size) fraction of frames from the beginning of each independent run, to calculate statistics. ```nskip``` is used to *thin* out the samples collected for analysis, i.e. every ```nskip```^th  frame is selected. Finally, ```plot_fmt``` specifies the file extension of all matplotlib figures generated. You should only set ```detect_equilibration=False``` if you are testing your analysis script and need it to run fast without waiting for calculating the exact length of the monte carlo burn-in phase. 
 
 2. Add the restraints that you want to be analyzed:
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ These scripts are used to analyze a series of trajectories, look at their scores
 
 ```python
 AT = AnalysisTrajectories(out_dirs,
-						  dir_name = 'run_',
+                          dir_name = 'run_',
                           analysis_dir = analysis_dir,
                           detect_equilibration=True,
                           burn_in=1000,
                           nskip=200,
                           nproc=1,
-                          plot_fmt="pdf")
+                          plot_fmt='pdf')
 ```
 The minimum set of arguments to specify are ```dir_name```: the prefix of the run folders, ```analysis_dir```: the directory where all analysis output will be written, and ```nproc```: the number of processors that are used to do parallel I/O. Additional options are: ```detect_equilibration``` which when set to ```False``` turns off rigorous statistical determination of the burn-in  or equilibration phase and instead just discards a constant ```burn_in``` frames from each independent run, to calculate statistics. ```nskip``` is used to *thin* out the samples collected for analysis, i.e. every ```nskip```^th  frame is selected. Finally, ```plot_fmt``` specifies the file extension of all matplotlib figures generated. You should only set ```detect_equilibration=False``` if you are testing your analysis script and need it to run fast without waiting for calculating the exact length of the monte carlo burn-in phase. 
 

--- a/pyext/src/equilibration.py
+++ b/pyext/src/equilibration.py
@@ -88,7 +88,7 @@ def statisticalInefficiency_multiscale(A_n, B_n=None, fast=False, mintime=3):
 
     # Be sure A_n and B_n have the same dimensions.
     if(A_n.shape != B_n.shape):
-        raise Exception('A_n and B_n must have same dimensions.')
+        raise ValueError('A_n and B_n must have same dimensions.')
 
     # Initialize statistical inefficiency estimate with uncorrelated value.
     g = 1.0
@@ -106,7 +106,7 @@ def statisticalInefficiency_multiscale(A_n, B_n=None, fast=False, mintime=3):
 
     # Trap the case where this covariance is zero, and we cannot proceed.
     if(sigma2_AB == 0):
-        raise ParameterError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
+        raise ValueError('Sample covariance sigma_AB^2 = 0 -- cannot compute statistical inefficiency')
 
     # Accumulate the integrated correlation time by computing the normalized correlation time at
     # increasing values of t.  Stop accumulating if the correlation function goes negative, since
@@ -181,7 +181,7 @@ def statisticalInefficiency_geyer(A_n, method='pos'):
     """
 
     if method not in ['pos', 'dec', 'con']:
-        raise Exception("Unknown method '%s'; must be one of ['pos', 'dec', 'con']" % method)
+        raise TypeError("Unknown method '%s'; must be one of ['pos', 'dec', 'con']" % method)
 
     # Create numpy copies of input arguments.
     A_n = np.array(A_n)
@@ -337,7 +337,7 @@ def detectEquilibration(A_t, nskip=1, method='multiscale'):
     elif method == 'geyer':
         statisticalInefficiency = statisticalInefficiency_geyer
     else:
-        raise Exception("Method must be one of ['multiscale', 'geyer']")
+        raise TypeError("Method must be one of ['multiscale', 'geyer']")
 
     g_t = np.ones([T - 1], np.float32)
     Neff_t = np.ones([T - 1], np.float32)


### PR DESCRIPTION
Cosmetic changes
-------------------------
1) Fixed file paths throughout the code. It was an inconsistent mix of ```os.path.join``` and using the backlash and "+" to add paths together. Moving ahead, lets not use the backlash and "+" option; it can break things more often than not.

2) Cleared up some bugs that had appeared in  ```do_extract_models_single_rmf```, since @saltzberg 's last commit. Also tidied up that method, e.g. the ```subprocess.check_call``` was implemented with ```shell=True``` which is a known security flaw and is not recommended; removed it and used the much safer (and simpler) ```shutil.use```.

3) Added an option for figure filename extensions other than 'pdf'. The default option is still pdf.

4)  Added an option ```burn_in``` which is set to a default of 1000. This assumes that the first 1000 frames constitute the burn_in phase of the monte carlo and discards them prior to collecting statistics. This was already achieved through the ```th``` attribute, but it is made explicit now. 

5) Added appropriate documentation to the ```AnalysisTrajectories``` constructor and to the README.

Non-cosmetic changes
-------------------------------
1) Added an option ```detect_equilibraton``` (True by default). Turning this off, turns off the statistical inefficiency based equilibration phase determination, and prevents errors during testing time as reported in [this issue](https://github.com/salilab/imp_analysis_tutorial/issues/4) . Basically, I would want to run a super short, potentially un-converged sampling, and still be able to use the analysis pipeline to test that everything is working well; currently, the equilibration detection routine would throw away all of the frames for such a short trajectory and the rest of the pipeline would collapse. 

3) Added an option ```do_sum``` (True by default) to the ```set_analyze_score_only_restraint``` method. By default, this will add all scores for custom restraints of the same type (i.e. whose restraint handle string starts with the same substring in the stat file). If you want to cluster by individual values of score-only-restraints, just turn this option off.  
